### PR TITLE
Fix missing queryFn in useWords hook

### DIFF
--- a/lang-portal/frontend/app/ClientLayout.tsx
+++ b/lang-portal/frontend/app/ClientLayout.tsx
@@ -15,6 +15,40 @@ import "../instrumentation-client"
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      // Provide a resilient default query function so queries without an explicit queryFn still work
+      // Supports both simple queries: ['endpoint'] and with params: ['endpoint', { page: 1, pageSize: 20 }]
+      // Also supports infinite queries by honoring pageParam when present
+      queryFn: async ({ queryKey, pageParam, signal }: any) => {
+        const [endpointOrUrl, paramsFromKey] = queryKey as [string, Record<string, any> | undefined]
+
+        // Build base URL - allow absolute/relative URLs, otherwise prefix our API base
+        let url = endpointOrUrl
+        if (typeof url === 'string' && !url.startsWith('/') && !url.startsWith('http')) {
+          url = `/api/langportal/${url}`
+        }
+
+        // Merge params from key and pageParam (for infinite queries)
+        const params: Record<string, any> = { ...(paramsFromKey || {}) }
+        if (pageParam !== undefined) {
+          params.page = pageParam
+        }
+
+        const qs = new URLSearchParams(
+          Object.entries(params).reduce((acc, [k, v]) => {
+            if (v !== undefined && v !== null) acc[k] = String(v)
+            return acc
+          }, {} as Record<string, string>)
+        ).toString()
+
+        const fullUrl = qs ? `${url}${url.includes('?') ? '&' : '?'}${qs}` : url
+
+        const res = await fetch(fullUrl, { signal })
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          throw new Error(`Request failed ${res.status}: ${text || fullUrl}`)
+        }
+        return res.json()
+      },
       staleTime: 1000 * 60 * 5, // 5 minutes
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
Add a default `queryFn` to `QueryClient` to resolve "No queryFn was passed" errors.

This default function handles various query key formats, including `pageParam` for infinite queries, and constructs API requests to `/api/langportal/` endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4b4a693-4d4e-491e-af4e-43923e388026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4b4a693-4d4e-491e-af4e-43923e388026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

