### PR TITLE
fix: detect subscription status on pricing + onboarding tour

### DIFF
--- a/lang-portal/frontend/app/pricing/page.tsx
+++ b/lang-portal/frontend/app/pricing/page.tsx
@@ -12,6 +12,11 @@ import { useTourContinuation } from "@/hooks/use-tour-continuation"
 export default function PricingPage() {
     const [isVisible, setIsVisible] = useState(false)
     const { isLoaded, hasActiveSubscription, plan } = useSubscription()
+    const hasPaidPlan = isLoaded && hasActiveSubscription
+    const heroTitle = hasPaidPlan ? "Manage Your Plan" : "Choose Your Plan"
+    const heroDescription = hasPaidPlan
+        ? "Your subscription is active. Review available plans anytime if you want to switch or upgrade."
+        : "Unlock all AI-powered features and accelerate your Japanese learning journey"
     // Continue tour if needed
     useTourContinuation()
 
@@ -44,7 +49,7 @@ export default function PricingPage() {
                         transition={{ duration: 0.5, delay: 0.1 }}
                         className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-4"
                     >
-                        Choose Your Plan
+                        {heroTitle}
                     </motion.h1>
 
                     <motion.p
@@ -53,11 +58,11 @@ export default function PricingPage() {
                         transition={{ duration: 0.5, delay: 0.2 }}
                         className="text-xl text-muted-foreground mb-6"
                     >
-                        Unlock all AI-powered features and accelerate your Japanese learning journey
+                        {heroDescription}
                     </motion.p>
 
                     {/* Active Subscription Badge */}
-                    {isLoaded && hasActiveSubscription && (
+                    {hasPaidPlan && (
                         <motion.div
                             initial={{ opacity: 0, y: 20 }}
                             animate={{ opacity: isVisible ? 1 : 0, y: isVisible ? 0 : 20 }}
@@ -118,7 +123,7 @@ export default function PricingPage() {
                             }}
                         />
                         {/* Highlight active plan */}
-                        {isLoaded && hasActiveSubscription && (
+                        {hasPaidPlan && (
                             <div className="absolute top-4 right-4">
                                 <Badge className="bg-blue-300 hover:bg-blue-600">
                                     <Check className="h-3 w-3 mr-1" />
@@ -129,7 +134,7 @@ export default function PricingPage() {
                     </div>
                     <div className="text-center mt-6">
                         <p className="text-sm text-muted-foreground">
-                            By subscribing, you agree to our{" "}
+                            {hasPaidPlan ? "Plan changes are subject to our " : "By subscribing, you agree to our "}
                             <Link href="/terms" className="text-blue-600 dark:text-blue-400 hover:underline">
                                 Terms of Service
                             </Link>
@@ -146,4 +151,3 @@ export default function PricingPage() {
         </main>
     )
 }
-

--- a/lang-portal/frontend/components/common/tour-guide.tsx
+++ b/lang-portal/frontend/components/common/tour-guide.tsx
@@ -6,6 +6,7 @@ import { useUser } from "@clerk/nextjs"
 import { Button } from "@/components/ui/button"
 import { studyOptions } from "@/components/study-session/constants"
 import { setTourContinue } from "@/hooks/use-tour-continuation"
+import { useSubscription } from "@/components/subscription/subscription-gate"
 
 // Custom CSS to be injected for driver.js styling to match our site design
 const customStyles = `
@@ -317,6 +318,10 @@ let globalDriverRef: any = null
 let globalStyleElRef: HTMLStyleElement | null = null
 let isInitializing = false
 
+interface TourStartOptions {
+  hasActiveSubscription?: boolean
+}
+
 // Helper to wait for element to appear
 function waitForElement(selector: string, timeout = 5000): Promise<Element | null> {
   return new Promise((resolve) => {
@@ -347,8 +352,9 @@ function waitForElement(selector: string, timeout = 5000): Promise<Element | nul
 }
 
 // Initialize tour on a specific page (exported for use by tour continuation hook)
-export async function startTourFromPage(pathname: string, router?: any, startTransition?: any) {
+export async function startTourFromPage(pathname: string, router?: any, startTransition?: any, options?: TourStartOptions) {
   if (typeof window === 'undefined') return
+  const hasActiveSubscription = Boolean(options?.hasActiveSubscription)
   
   // Reset initialization flag if driver was destroyed (allows tour to continue on new page)
   if (!globalDriverRef && isInitializing) {
@@ -509,56 +515,11 @@ export async function startTourFromPage(pathname: string, router?: any, startTra
         }
       }
 
-      // Final step to navigate to pricing
-      studySteps.push({
-        popover: {
-          title: "Ready to Unlock All Features?",
-          description: "Subscribe to access all these amazing learning tools and more!",
-          onNextClick: () => {
-            console.log('[Tour] Navigating to pricing page')
-            if (globalDriverRef) {
-              globalDriverRef.destroy()
-              globalDriverRef = null
-            }
-            // Reset initialization flag to allow tour to continue on new page
-            isInitializing = false
-            // Set flag to continue tour on pricing page BEFORE navigation
-            setTourContinue('/pricing')
-            console.log('[Tour] Set continue flag for /pricing')
-            
-            // Navigate immediately - localStorage is synchronous
-            if (router && startTransition) {
-              startTransition(() => {
-                router.push("/pricing")
-              })
-            } else {
-              window.location.href = "/pricing"
-            }
-            return false
-          }
-        }
-      })
-
-      steps = studySteps
-    } else if (pathname === '/pricing') {
-      // Pricing page steps
-      steps = [
-        {
-          element: "#pricing-hero",
+      if (hasActiveSubscription) {
+        studySteps.push({
           popover: {
-            title: "Choose Your Plan",
-            description: "Select the perfect plan for your learning journey. All plans include access to our comprehensive learning tools.",
-            side: "bottom",
-            align: "center",
-          }
-        },
-        {
-          element: "#pricing-table-section",
-          popover: {
-            title: "Subscribe to Unlock Everything",
-            description: "Choose Basic for essential features or Pro for unlimited AI companion sessions and priority support. Start your subscription to begin learning!",
-            side: "top",
-            align: "center",
+            title: "You're All Set",
+            description: "You already have an active plan. Explore any study feature and start learning right away!",
             onNextClick: () => {
               if (globalDriverRef) {
                 globalDriverRef.destroy()
@@ -569,8 +530,92 @@ export async function startTourFromPage(pathname: string, router?: any, startTra
               return false
             }
           }
-        }
-      ]
+        })
+      } else {
+        // Final step to navigate to pricing for non-subscribed users
+        studySteps.push({
+          popover: {
+            title: "Ready to Unlock All Features?",
+            description: "Subscribe to access all these amazing learning tools and more!",
+            onNextClick: () => {
+              console.log('[Tour] Navigating to pricing page')
+              if (globalDriverRef) {
+                globalDriverRef.destroy()
+                globalDriverRef = null
+              }
+              // Reset initialization flag to allow tour to continue on new page
+              isInitializing = false
+              // Set flag to continue tour on pricing page BEFORE navigation
+              setTourContinue('/pricing')
+              console.log('[Tour] Set continue flag for /pricing')
+              
+              // Navigate immediately - localStorage is synchronous
+              if (router && startTransition) {
+                startTransition(() => {
+                  router.push("/pricing")
+                })
+              } else {
+                window.location.href = "/pricing"
+              }
+              return false
+            }
+          }
+        })
+      }
+
+      steps = studySteps
+    } else if (pathname === '/pricing') {
+      // Pricing page steps
+      steps = hasActiveSubscription
+        ? [
+            {
+              element: "#pricing-hero",
+              popover: {
+                title: "Subscription Overview",
+                description: "Your active plan is detected. You can review options here whenever you want to upgrade or switch.",
+                side: "bottom",
+                align: "center",
+                onNextClick: () => {
+                  if (globalDriverRef) {
+                    globalDriverRef.destroy()
+                    globalDriverRef = null
+                  }
+                  markTourCompleted()
+                  clearTourProgress()
+                  return false
+                }
+              }
+            }
+          ]
+        : [
+            {
+              element: "#pricing-hero",
+              popover: {
+                title: "Choose Your Plan",
+                description: "Select the perfect plan for your learning journey. All plans include access to our comprehensive learning tools.",
+                side: "bottom",
+                align: "center",
+              }
+            },
+            {
+              element: "#pricing-table-section",
+              popover: {
+                title: "Subscribe to Unlock Everything",
+                description: "Choose Basic for essential features or Pro for unlimited AI companion sessions and priority support. Start your subscription to begin learning!",
+                side: "top",
+                align: "center",
+                onNextClick: () => {
+                  if (globalDriverRef) {
+                    globalDriverRef.destroy()
+                    globalDriverRef = null
+                  }
+                  markTourCompleted()
+                  clearTourProgress()
+                  return false
+                }
+              }
+            }
+          ]
     }
 
     // Wait for first element to be available (longer timeout for study page)
@@ -734,6 +779,7 @@ export async function startTourFromPage(pathname: string, router?: any, startTra
 export default function TourGuide() {
   const router = useRouter()
   const { isSignedIn } = useUser()
+  const { hasActiveSubscription } = useSubscription()
   const [isPending, startTransition] = useTransition()
   const [isLoading, setIsLoading] = useState(false)
   
@@ -758,10 +804,14 @@ export default function TourGuide() {
       })
       // Wait for navigation then start tour
       setTimeout(() => {
-        startTourFromPage('/', routerRef.current, startTransition)
+        startTourFromPage('/', routerRef.current, startTransition, {
+          hasActiveSubscription,
+        })
       }, 1000)
     } else {
-      await startTourFromPage('/', routerRef.current, startTransition)
+      await startTourFromPage('/', routerRef.current, startTransition, {
+        hasActiveSubscription,
+      })
     }
   }
 

--- a/lang-portal/frontend/components/subscription/subscription-gate.tsx
+++ b/lang-portal/frontend/components/subscription/subscription-gate.tsx
@@ -16,6 +16,37 @@ interface SubscriptionGateProps {
   fallback?: React.ReactNode
 }
 
+type NormalizedPlan = "basic" | "pro" | "free" | null
+
+function normalizeSubscriptionPlan(rawPlan: unknown): NormalizedPlan {
+  if (typeof rawPlan !== "string") {
+    return null
+  }
+
+  const normalized = rawPlan.toLowerCase()
+  if (normalized === "pro" || normalized === "basic" || normalized === "free") {
+    return normalized
+  }
+
+  return null
+}
+
+function resolveSubscriptionState(has: ReturnType<typeof useAuth>["has"], metadataPlan: NormalizedPlan) {
+  const hasBasicPlan = Boolean(has?.({ plan: "basic" }) || metadataPlan === "basic")
+  const hasProPlan = Boolean(has?.({ plan: "pro" }) || metadataPlan === "pro")
+  const hasFreePlan = Boolean(has?.({ plan: "free" }) || metadataPlan === "free")
+  const hasActiveSubscription = hasBasicPlan || hasProPlan
+  const plan: NormalizedPlan = hasProPlan ? "pro" : hasBasicPlan ? "basic" : hasFreePlan ? "free" : null
+
+  return {
+    hasActiveSubscription,
+    isPro: hasProPlan,
+    isBasic: hasBasicPlan,
+    isFree: hasFreePlan,
+    plan,
+  }
+}
+
 /**
  * SubscriptionGate - Protects content behind subscription requirement
  * 
@@ -33,14 +64,8 @@ export function SubscriptionGate({
   const router = useRouter()
 
   const isLoaded = authLoaded && userLoaded
-
-  // Check subscription using Clerk's has() method
-  // Only paid plans (basic, pro) are considered active for gating.
-  // The Clerk "free" plan is treated as non-paid and does not unlock features.
-  const hasBasicPlan = has?.({ plan: 'basic' }) ?? false
-  const hasProPlan = has?.({ plan: 'pro' }) ?? false
-  const hasFreePlan = has?.({ plan: 'free' }) ?? false
-  const hasActiveSubscription = hasBasicPlan || hasProPlan
+  const metadataPlan = normalizeSubscriptionPlan(user?.publicMetadata?.["subscription_plan"])
+  const { hasActiveSubscription } = resolveSubscriptionState(has, metadataPlan)
 
   // Show loading state
   if (!isLoaded && showLoading) {
@@ -123,23 +148,14 @@ export function SubscriptionGate({
  */
 export function useSubscription() {
   const { has, isLoaded: authLoaded } = useAuth()
-  const { isLoaded: userLoaded } = useUser()
+  const { user, isLoaded: userLoaded } = useUser()
 
   const isLoaded = authLoaded && userLoaded
-
-  // Use Clerk's has() method to check plans.
-  // Only basic/pro are treated as active paid subscriptions; free is informational only.
-  const hasBasicPlan = has?.({ plan: 'basic' }) ?? false
-  const hasProPlan = has?.({ plan: 'pro' }) ?? false
-  const hasFreePlan = has?.({ plan: 'free' }) ?? false
-  const hasActiveSubscription = hasBasicPlan || hasProPlan
+  const metadataPlan = normalizeSubscriptionPlan(user?.publicMetadata?.["subscription_plan"])
+  const subscriptionState = resolveSubscriptionState(has, metadataPlan)
 
   return {
     isLoaded,
-    hasActiveSubscription,
-    isPro: hasProPlan,
-    isBasic: hasBasicPlan,
-    isFree: hasFreePlan,
-    plan: hasProPlan ? 'pro' : hasBasicPlan ? 'basic' : hasFreePlan ? 'free' : null,
+    ...subscriptionState,
   }
 }

--- a/lang-portal/frontend/hooks/use-tour-continuation.ts
+++ b/lang-portal/frontend/hooks/use-tour-continuation.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react"
 import { usePathname } from "next/navigation"
+import { useSubscription } from "@/components/subscription/subscription-gate"
 
 const TOUR_CONTINUE_KEY = 'sorami-tour-continue'
 
@@ -84,6 +85,7 @@ function waitForTourElements(pathname: string): Promise<boolean> {
 
 export function useTourContinuation() {
   const pathname = usePathname()
+  const { isLoaded: subscriptionLoaded, hasActiveSubscription } = useSubscription()
   const hasContinuedRef = useRef<string | null>(null)
   const observerRef = useRef<MutationObserver | null>(null)
 
@@ -93,6 +95,11 @@ export function useTourContinuation() {
     // Check if tour should continue on this page
     const shouldContinue = localStorage.getItem(TOUR_CONTINUE_KEY)
     console.log('[Tour] Hook running - pathname:', pathname, 'shouldContinue:', shouldContinue, 'hasContinued:', hasContinuedRef.current)
+
+    // Ensure subscription state is ready before deciding whether paywall steps should appear.
+    if (!subscriptionLoaded) {
+      return
+    }
     
     // Only proceed if:
     // 1. There's a continue flag set
@@ -125,7 +132,9 @@ export function useTourContinuation() {
           const { startTourFromPage } = await import('@/components/common/tour-guide')
           
           // Call without router/startTransition - it will use window.location if needed
-          await startTourFromPage(pathname)
+          await startTourFromPage(pathname, undefined, undefined, {
+            hasActiveSubscription,
+          })
           
           // Clear the flag only after tour successfully starts
           localStorage.removeItem(TOUR_CONTINUE_KEY)
@@ -152,7 +161,7 @@ export function useTourContinuation() {
         observerRef.current = null
       }
     }
-  }, [pathname])
+  }, [pathname, subscriptionLoaded, hasActiveSubscription])
 }
 
 export function setTourContinue(pathname: string): void {


### PR DESCRIPTION
## Summary
- unify subscription detection in `useSubscription` with Clerk plan checks plus metadata fallback
- gate tour continuation on subscription state readiness so paywall steps render consistently
- make tour paywall/pricing steps conditional for subscribed users
- update pricing page hero/copy to reflect active plan state consistently

## Testing
- `pnpm lint` (fails in this worktree because `node_modules` is missing; `next: command not found`)

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing page now displays personalized messaging based on subscription status.
  * Guided tour flow adapts dynamically—active subscribers see a subscription overview, while new users receive pricing navigation prompts.
  * Enhanced subscription state management throughout the application for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->