### PR TITLE
Fix mobile pricing page scroll lock

### DIFF
--- a/lang-portal/frontend/app/pricing/page.tsx
+++ b/lang-portal/frontend/app/pricing/page.tsx
@@ -22,16 +22,10 @@ export default function PricingPage() {
 
     useEffect(() => {
         setIsVisible(true)
-        // Disable body scrolling
-        document.body.style.overflow = 'hidden'
-        return () => {
-            // Re-enable scrolling when component unmounts
-            document.body.style.overflow = 'unset'
-        }
     }, [])
 
     return (
-        <main className="flex flex-col gap-12 pb-20 pt-8 overflow-hidden">
+        <main className="flex flex-col gap-12 overflow-x-hidden pb-20 pt-8">
             {/* Hero Section */}
             <section id="pricing-hero" className="container mx-auto px-4">
                 <div className="text-center max-w-3xl mx-auto">


### PR DESCRIPTION
## Problem
The pricing page locks document scrolling on mount.
On mobile, that prevents users from reaching the lower pricing content, including the Pro option.

## Overview
- remove the pricing page body scroll lock
- keep only horizontal overflow clipped on the page wrapper
- restore normal vertical scrolling on mobile without changing the existing pricing layout

## Testing
- Not run: frontend lint/test tooling is unavailable in this worktree because `eslint` is not installed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed scrolling behavior on the pricing page. Users can now scroll vertically through all pricing content without restrictions, while horizontal overflow is properly prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->