### PR TITLE
fix(auth): restore Clerk signup CSP

### DIFF
--- a/lang-portal/frontend/middleware.ts
+++ b/lang-portal/frontend/middleware.ts
@@ -60,6 +60,18 @@ function toCspSource(value: string | undefined): string | null {
   return `https://${trimmed}`;
 }
 
+function toCspOrigin(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value.trim()).origin;
+  } catch {
+    return null;
+  }
+}
+
 function toWebSocketSource(source: string): string | null {
   if (source.startsWith('https://')) {
     return `wss://${source.slice('https://'.length)}`;
@@ -76,10 +88,6 @@ function uniqueSources(values: Array<string | null | undefined>): string[] {
   return [...new Set(values.filter((value): value is string => Boolean(value)))];
 }
 
-function joinDirective(name: string, ...values: string[]): string {
-  return [name, ...values.filter(Boolean)].join(' ');
-}
-
 function getAllowedHttpsSources(): string[] {
   return uniqueSources([
     toCspSource(process.env['NEXT_PUBLIC_APP_URL']),
@@ -90,6 +98,13 @@ function getAllowedHttpsSources(): string[] {
     toCspSource(process.env['NEXT_PUBLIC_POSTHOG_UI_HOST']),
     'https://api.vapi.ai',
     'https://*.daily.co',
+  ]);
+}
+
+function getAdditionalConnectHttpsSources(): string[] {
+  return uniqueSources([
+    toCspOrigin(process.env['SENTRY_DSN']),
+    toCspOrigin(process.env['NEXT_PUBLIC_SENTRY_DSN']),
   ]);
 }
 
@@ -117,11 +132,6 @@ function isPostHogProxyRequest(pathname: string, proxyPath: string): boolean {
 
 export default clerkMiddleware(async (auth, req) => {
   const posthogProxyPath = getPostHogProxyPath();
-  const isProduction = process.env['NODE_ENV'] === 'production';
-  const allowedHttpsSources = getAllowedHttpsSources();
-  const allowedWssSources = uniqueSources(allowedHttpsSources.map(toWebSocketSource));
-  const devHttpSources = isProduction ? [] : ['http://localhost:*', 'http://127.0.0.1:*'];
-  const devWsSources = isProduction ? [] : ['ws://localhost:*', 'ws://127.0.0.1:*'];
 
   // Redirect /home to /
   if (req.nextUrl.pathname === '/home') {
@@ -146,55 +156,50 @@ export default clerkMiddleware(async (auth, req) => {
     }
   }
 
-  // Generate a per-request CSP nonce and pass it downstream via headers
-  const nonce = crypto.randomUUID().replace(/-/g, '');
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.set('x-nonce', nonce);
-
-  // Create response with security headers
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
-
-  // Third-party allowances for Clerk, PostHog, Vapi, and Daily are scoped to
-  // the specific directives below instead of default-src.
-  const cspDirectives = [
-    joinDirective("default-src", "'self'", ...allowedHttpsSources, 'blob:'),
-    // 'unsafe-eval' is required by Daily.co's call-machine bundle which uses eval() internally.
-    // See: https://docs.daily.co/reference/daily-js/content-security-policy
-    joinDirective("script-src", "'self'", `'nonce-${nonce}'`, "'unsafe-eval'", ...allowedHttpsSources, 'blob:'),
-    joinDirective("style-src", "'self'", ...allowedHttpsSources, "'unsafe-inline'"),
-    joinDirective("img-src", "'self'", ...allowedHttpsSources, 'data:', 'blob:'),
-    joinDirective("font-src", "'self'", ...allowedHttpsSources, 'data:'),
-    joinDirective(
-      "connect-src",
-      "'self'",
-      ...allowedHttpsSources,
-      ...allowedWssSources,
-      ...devHttpSources,
-      ...devWsSources,
-    ),
-    joinDirective("frame-src", "'self'", ...allowedHttpsSources, 'blob:', 'data:', 'about:'),
-    joinDirective("media-src", "'self'", ...allowedHttpsSources, 'blob:', 'data:'),
-    "object-src 'none'",
-    "base-uri 'self'",
-    joinDirective("form-action", "'self'", ...allowedHttpsSources),
-    // Note: CSP sandbox interferes with Clerk CAPTCHA/Apple PAT iframes (about:blank)
-    // and blocks script execution inside the challenge frame. Avoid sandboxing the
-    // entire document; rely on Clerk + frame-src restrictions instead.
-    "upgrade-insecure-requests",
-  ];
-
-  const cspHeader = cspDirectives.join('; ');
-
-  // Set security headers
-  response.headers.set('Content-Security-Policy', cspHeader);
+  const response = NextResponse.next();
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  
+
   return response;
+}, () => {
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  const allowedHttpsSources = getAllowedHttpsSources();
+  const connectHttpsSources = uniqueSources([
+    ...allowedHttpsSources,
+    ...getAdditionalConnectHttpsSources(),
+  ]);
+  const allowedWssSources = uniqueSources(allowedHttpsSources.map(toWebSocketSource));
+  const devHttpSources = isProduction ? [] : ['http://localhost:*', 'http://127.0.0.1:*'];
+  const devWsSources = isProduction ? [] : ['ws://localhost:*', 'ws://127.0.0.1:*'];
+
+  // Clerk's generated strict CSP covers its nonce handling, Turnstile frames,
+  // and App Router inline scripts. We only merge the app-specific hosts here.
+  return {
+    contentSecurityPolicy: {
+      strict: true,
+      directives: {
+        'script-src': uniqueSources([
+          'https://challenges.cloudflare.com',
+          ...allowedHttpsSources,
+          'blob:',
+        ]),
+        'style-src': allowedHttpsSources,
+        'img-src': uniqueSources([...allowedHttpsSources, 'data:', 'blob:']),
+        'font-src': uniqueSources([...allowedHttpsSources, 'data:']),
+        'connect-src': uniqueSources([
+          ...connectHttpsSources,
+          ...allowedWssSources,
+          ...devHttpSources,
+          ...devWsSources,
+        ]),
+        'frame-src': uniqueSources([...allowedHttpsSources, 'blob:', 'data:', 'about:']),
+        'media-src': uniqueSources([...allowedHttpsSources, 'blob:', 'data:']),
+        'object-src': ['none'],
+        'base-uri': ['self'],
+        'form-action': allowedHttpsSources,
+      },
+    },
+  };
 });
 
 export const config = {


### PR DESCRIPTION
- switch frontend middleware to Clerk strict CSP generation\n- merge app-specific CSP sources for Turnstile, PostHog, Daily, Vapi, and Sentry\n- keep the fix scoped to the signup regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Content Security Policy configuration for enhanced security and stability.
  * Optimized error tracking integration with enhanced source handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->